### PR TITLE
test: exercise pr-triage workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,4 +130,4 @@ PRs may be closed if:
 
 ## Questions?
 
-[Discussions](https://github.com/apache/iggy/discussions) or [Discord](https://discord.gg/apache-iggy)
+[Discussions](https://github.com/apache/iggy/discussions) or [Discord](https://discord.gg/apache-iggy).


### PR DESCRIPTION
Test PR for the comment-driven triage workflow on this fork.

Will exercise:
- `r? @user`
- `@iggybot ready`
- `@iggybot author`
- non-committer auth gate
- no-match comments

Trivial CONTRIBUTING.md tweak (added trailing period) so the PR has a real diff.